### PR TITLE
Fixed issue with option removeGlossaryButton

### DIFF
--- a/catppuccin.user.css
+++ b/catppuccin.user.css
@@ -923,7 +923,7 @@
     }
     
     if (removeGlossaryButton) {
-        .Target--KAb3e {
+        .lmt__glossary_button {
             display: none;
         }
     }


### PR DESCRIPTION
When enabling removeGlossaryButton all buttons inside the translation box are hidden. This is fix for that :)