### PR TITLE
fix: Hide the entire glossary button if 'removeGlossaryButton' is enabled

### DIFF
--- a/catppuccin.user.css
+++ b/catppuccin.user.css
@@ -923,7 +923,7 @@
     }
     
     if (removeGlossaryButton) {
-        .lmt__glossary_button {
+        .lmt__glossaryButton__desktop {
             display: none;
         }
     }


### PR DESCRIPTION
Just noticed that there was a tiny bit of the button visible.
![image](https://github.com/catppuccin/deepl/assets/75657829/4cc5538e-5f2e-46fb-b74e-b146812c0a18)
